### PR TITLE
Add possibly to mount custom secrets

### DIFF
--- a/charts/anything-llm/templates/deployment.yaml
+++ b/charts/anything-llm/templates/deployment.yaml
@@ -26,14 +26,17 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "anything-llm.fullname" . }}-config
-          {{- if .Values.secret.enabled }}
+            {{- if .Values.secret.enabled }}
             - secretRef:
                 name: {{ include "anything-llm.fullname" . }}-secret
-          {{- end }}
+            {{- end }}
           volumeMounts:
             {{- range .Values.persistence.volumes }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
             {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -45,7 +48,14 @@ spec:
       volumes:
         {{- range .Values.persistence.volumes }}
         - name: {{ .name }}
+          {{- if .claimName }}
           persistentVolumeClaim:
-            claimName: {{ .name }}
+            claimName: {{ .claimName }}
+          {{- else if .secretName }}
+          secret:
+            secretName: {{ .secretName }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- end }}
       restartPolicy: Always


### PR DESCRIPTION
This change allows to mount custom secrets in to the anything-llm container

I needed this to apply a custom root ca via `NODE_EXTRA_CA_CERTS` 

example values file:
```
persistence:
  enabled: true
  accessMode: ReadWriteOnce
  size: 10Gi
  volumes:
    - name: server-storage
      mountPath: /app/server/storage
      claimName: server-storage
    - name: ca-cert
      secretName: ca-bundle
      mountPath: /etc/ssl/certs/ca-certificates.crt
      subPath: ca-certificates.crt

config:
  NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
  
  ```

i don't know if this solution is correct, input appreciated. works for me on my cluster.