### PR TITLE
feat: add service annotations and enhance values.yaml documentation

### DIFF
--- a/charts/anything-llm/templates/service.yaml
+++ b/charts/anything-llm/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "anything-llm.fullname" . }}
   labels:
     {{- include "anything-llm.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     {{- include "anything-llm.selectorLabels" . | nindent 4 }}

--- a/charts/anything-llm/values.yaml
+++ b/charts/anything-llm/values.yaml
@@ -20,6 +20,10 @@ service:
   type: ClusterIP
   # -- Service port.
   port: 3001
+    # -- Optional annotations for the Service.
+  # annotations:
+    # Example for GCE Ingress on Google Cloud (enables NEG):
+    # cloud.google.com/neg: '{"ingress": true}'
 
 # -- Ingress configuration.
 ingress:


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability for users to specify custom annotations for the Kubernetes `Service` object.

## Why is this change necessary?

Adding annotations to a Service is a common requirement for integrating with various cloud-native tools. A key use case is for cloud provider load balancers, such as enabling Network Endpoint Groups (NEG) for a GCE Ingress on Google Kubernetes Engine, which requires the `cloud.google.com/neg: '{"ingress": true}'` annotation.

This change provides this essential flexibility directly within the chart, preventing the need for users to fork the chart to implement this feature.

## How was this change implemented?

-   **`templates/service.yaml`**: A conditional block was added to render an `annotations` section if `.Values.service.annotations` is defined. This uses the standard Helm practice of `with/toYaml/nindent` for correctness and flexibility.
-   **`values.yaml`**: A new `service.annotations` parameter has been added, including a commented-out example for GCE Ingress to guide the user.

## How has this been tested?

-   The chart was validated with `helm lint`.
-   `helm template` was used to confirm that the `annotations:` block is correctly rendered when values are provided and is omitted entirely when they are not, ensuring backward compatibility.